### PR TITLE
chore(saucelabs): use concurrency option introduced in Karma 0.13.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "gulp-uglify": "1.4.2",
     "gulp-webserver": "0.9.1",
     "karma": "0.13.14",
-    "karma-chrome-launcher": "0.2.0",
+    "karma-chrome-launcher": "0.2.1",
     "karma-firefox-launcher": "0.1.6",
     "karma-mocha": "0.2.0",
     "karma-opera-launcher": "0.3.0",

--- a/task/test.js
+++ b/task/test.js
@@ -38,6 +38,7 @@ module.exports = function (opts, done) {
       captureTimeout: 120000,
       reporters: ['saucelabs', 'dots'],
       autoWatch: false,
+      concurrency: 5,
       client: {}
     });
   }


### PR DESCRIPTION
This uses the `concurrency` option for Karma: https://github.com/karma-runner/karma-sauce-launcher/issues/40
