### PR TITLE
Add a build step to replace source code env variables

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "gulp-if": "^2.0.0",
     "gulp-less": "3.0.3",
     "gulp-minify-css": "1.2.1",
+    "gulp-replace": "^0.5.4",
     "gulp-tap": "^0.1.3",
     "gulp-uglify": "1.4.2",
     "gulp-webserver": "0.9.1",

--- a/task/test-build.js
+++ b/task/test-build.js
@@ -3,16 +3,19 @@ var gulp = require('gulp');
 var gulpBabel = require('gulp-babel');
 var gulpConcat = require('gulp-concat');
 var gulpFilter = require('gulp-filter');
+var gulpReplace = require('gulp-replace');
 
 module.exports = function () {
   var filterEverythingExceptWebcomponents = gulpFilter(function (file) {
     return file.path.indexOf('webcomponents.js') === -1;
   }, { restore: true });
+
   return galv.trace('test/unit.js').createStream()
     .pipe(filterEverythingExceptWebcomponents)
     .pipe(galv.cache('babel', gulpBabel()))
     .pipe(filterEverythingExceptWebcomponents.restore)
     .pipe(galv.cache('globalize', galv.globalize()))
+    .pipe(galv.cache('envreplace', gulpReplace('process.env.NODE_ENV', '"development"')))
     .pipe(gulpConcat('unit.js'))
     .pipe(gulp.dest('.tmp'));
 };


### PR DESCRIPTION
Envify didn't work immediately, I think because it was written as a browserify plugin.

I could look into getting envify to work as a build step, but what I needed to compile
React was pretty basic, so I've gone with this solution.

I'm happy to return to using envify or an isolated plugin, but this seemed sufficient
for my purposes.

Alternatively, I could filter for react.js before doing this build step, if you think
that it could break other dependencies.
