### PR TITLE
Add latest iphone to the saucelabs launchers

### DIFF
--- a/lib/saucelabs-launchers.js
+++ b/lib/saucelabs-launchers.js
@@ -113,6 +113,13 @@ var browsers = {
     browserName: 'opera',
     platform: 'Windows 7',
     version: '12.12'
+  },
+
+  iphone: {
+    browserName: 'iphone',
+    platform: 'OS X 10.10',
+    version: 'latest',
+    deviceName: 'iPhone Simulator'
   }
 };
 


### PR DESCRIPTION
#152

We need to push saucelabs somehow to update their chrome version for the android platforms before we add android to the tests. Their chrome versions are really outdated.
