### PR TITLE
fix(tests): trigger release for BrowserStack integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,4 @@ Runs the tests once in Karma.
 ### `sk-tests-watch`
 
 Runs the tests in watch mode for development.
+


### PR DESCRIPTION
need to do this because the previous commits used `chore:` which doesn't trigger a release.
