### PR TITLE
fix(tests): enable opera 12 browserstack tests again

### DIFF
--- a/browserstack.browsers.js
+++ b/browserstack.browsers.js
@@ -115,6 +115,14 @@ const browserstackBrowsers = {
     os: 'WINDOWS',
     os_version: '10',
   },
+
+  // Opera
+  opera_12: {
+    browser: 'opera',
+    os: 'WINDOWS',
+    os_version: '8.1',
+    browser_version: '12.16',
+  },
 };
 
 Object.keys(browserstackBrowsers).forEach((key) => {


### PR DESCRIPTION
I also attempted to re-enable Android on Browserstack, but it seems that we can't because
1. There's an issue running skatejs/skatejs against Android 4 where it maxes out the CPU
2. Browserstack's Android 5.0+ emulators don't support network proxies, which is needed to work with Karma (see http://stackoverflow.com/questions/37907739/running-karma-test-in-browserstack-in-mobile for more info)

Once item 1 above is resolved, we can enable android 4 by adding the following to the top of `browserstack.browsers.js`:

``` javascript
android: {
  os: 'android',
  os_version: '4.4',
  device: 'Samsung Galaxy Tab 4 10.1',
},
```
