### PR TITLE
fix(browserstack): use BrowserStack reporter

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -85,7 +85,7 @@ module.exports = function (config) {
     browsers: Object.keys(browserstackBrowsers),
     timeout: 300000,
     retryLimit: 3,
-    reporters: ['dots'],
+    reporters: ['dots', 'BrowserStack'],
     autoWatch: false,
     concurrency: 5,
 


### PR DESCRIPTION
used 'fix' cz type instead of 'chore' so a patch version gets released
