### PR TITLE
fix(rollup): fall back to unbroken rollup version

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "less-loader": "2.2.3",
     "mocha": "3.0.2",
     "npm": "3.10.7",
-    "rollup": "0.35.9",
+    "rollup": "0.34.13",
     "rollup-plugin-babel": "2.6.1",
     "rollup-plugin-commonjs": "4.1.0",
     "rollup-plugin-node-resolve": "2.0.0",


### PR DESCRIPTION
Rollup 0.35.x is having issues where this kind of thing is happening

```
skip(elem, name, value) {
  if (value) {
    elem[$skip] = true;
  } else {
    delete elem[$skip];
  }
},

// into...

skip: function incrementalDom.skip(elem, name$$1, value) {
  if (value) {
    elem[$skip] = true;
  } else {
    delete elem[$skip];
  }
}
```

which is causing issues for uglify.
