### PR TITLE
fix(browserstack): use iPad instead of iPhone

### DIFF
--- a/browserstack.browsers.js
+++ b/browserstack.browsers.js
@@ -1,9 +1,9 @@
 const browserstackBrowsers = {
   // iOS
-  iphone: {
+  ipad: {
     os: 'ios',
-    os_version: '9.1',
-    device: 'iPhone 6S',
+    os_version: '9.3',
+    device: 'iPad Pro',
   },
 
   // Important: make sure mobile browsers are first,


### PR DESCRIPTION
this should help with cases where the iOS tests stall because the Karma test fixture is pushed offscreen when there are lots of "Browser <x> is executing" karma rows on-screen.

Values are based on docs at https://www.browserstack.com/list-of-browsers-and-platforms?product=js_testing
